### PR TITLE
fix: protected event.properties from mutation in plugin-mixpanel

### DIFF
--- a/packages/plugin-mixpanel/lib/index.ts
+++ b/packages/plugin-mixpanel/lib/index.ts
@@ -50,7 +50,7 @@ export default class MixpanelBrowserPlugin extends PluginBase {
   track(userId: string | undefined, event: Event) {
     this.mixpanel.track(
       event.name,
-      event.properties,
+      { ...event.properties },
     );
   }
 


### PR DESCRIPTION
plugin-mixpanel-node doesn't have this problem since it destructures the object already (see https://github.com/iterativelyhq/itly-sdk/blob/996e5a57287ea37a02ca749c9644f02d7f6da90e/packages/plugin-mixpanel-node/lib/index.ts#L39)