### PR TITLE
fix: added simple README's to all  packages

### DIFF
--- a/packages/plugin-amplitude-node/README.md
+++ b/packages/plugin-amplitude-node/README.md
@@ -1,0 +1,3 @@
+# Amplitude Node Plugin
+
+[Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-amplitude-node/README.md
+++ b/packages/plugin-amplitude-node/README.md
@@ -1,3 +1,3 @@
-# Amplitude Node Plugin
+# Amplitude Node Plugin for Iteratively SDK
 
 [Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-amplitude-node/package.json
+++ b/packages/plugin-amplitude-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itly/plugin-amplitude-node",
   "version": "1.4.1",
-  "description": "Amplitude Node Plugin",
+  "description": "Amplitude Node Plugin for Iteratively SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/plugin-amplitude-node/package.json
+++ b/packages/plugin-amplitude-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itly/plugin-amplitude-node",
   "version": "1.4.1",
-  "description": "",
+  "description": "Amplitude Node Plugin",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/plugin-amplitude/README.md
+++ b/packages/plugin-amplitude/README.md
@@ -1,0 +1,3 @@
+# Amplitude Browser Plugin
+
+[Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-amplitude/README.md
+++ b/packages/plugin-amplitude/README.md
@@ -1,3 +1,3 @@
-# Amplitude Browser Plugin
+# Amplitude Browser Plugin for Iteratively SDK
 
 [Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-amplitude/package.json
+++ b/packages/plugin-amplitude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itly/plugin-amplitude",
   "version": "1.4.1",
-  "description": "Amplitude Browser Plugin",
+  "description": "Amplitude Browser Plugin for Iteratively SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/plugin-iteratively-node/README.md
+++ b/packages/plugin-iteratively-node/README.md
@@ -1,0 +1,3 @@
+# Iteratively Node Plugin
+
+[Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-iteratively-node/README.md
+++ b/packages/plugin-iteratively-node/README.md
@@ -1,3 +1,3 @@
-# Iteratively Node Plugin
+# Iteratively Node Plugin for Iteratively SDK
 
 [Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-iteratively-node/package.json
+++ b/packages/plugin-iteratively-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itly/plugin-iteratively-node",
   "version": "1.4.1",
-  "description": "Iteratively Node Plugin",
+  "description": "Iteratively Node Plugin for Iteratively SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/plugin-iteratively/README.md
+++ b/packages/plugin-iteratively/README.md
@@ -1,0 +1,3 @@
+# Iteratively Browser Plugin
+
+[Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-iteratively/README.md
+++ b/packages/plugin-iteratively/README.md
@@ -1,3 +1,3 @@
-# Iteratively Browser Plugin
+# Iteratively Browser Plugin for Iteratively SDK
 
 [Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-iteratively/package.json
+++ b/packages/plugin-iteratively/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itly/plugin-iteratively",
   "version": "1.4.1",
-  "description": "Iteratively Browser Plugin",
+  "description": "Iteratively Browser Plugin for Iteratively SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/plugin-mixpanel-node/README.md
+++ b/packages/plugin-mixpanel-node/README.md
@@ -1,0 +1,3 @@
+# Mixpanel Node Plugin
+
+[Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-mixpanel-node/README.md
+++ b/packages/plugin-mixpanel-node/README.md
@@ -1,3 +1,3 @@
-# Mixpanel Node Plugin
+# Mixpanel Node Plugin for Iteratively SDK
 
 [Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-mixpanel-node/package.json
+++ b/packages/plugin-mixpanel-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itly/plugin-mixpanel-node",
   "version": "1.4.1",
-  "description": "Mixpanel Node Plugin",
+  "description": "Mixpanel Node Plugin for Iteratively SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/plugin-mixpanel-node/package.json
+++ b/packages/plugin-mixpanel-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itly/plugin-mixpanel-node",
   "version": "1.4.1",
-  "description": "Mixpanel Node Plugin ",
+  "description": "Mixpanel Node Plugin",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/plugin-mixpanel/README.md
+++ b/packages/plugin-mixpanel/README.md
@@ -1,3 +1,3 @@
-# Mixpanel Browser Plugin
+# Mixpanel Browser Plugin for Iteratively SDK
 
 [Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-mixpanel/README.md
+++ b/packages/plugin-mixpanel/README.md
@@ -1,0 +1,3 @@
+# Mixpanel Browser Plugin
+
+[Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-mixpanel/package.json
+++ b/packages/plugin-mixpanel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itly/plugin-mixpanel",
   "version": "1.4.1",
-  "description": "Mixpanel Browser Plugin",
+  "description": "Mixpanel Browser Plugin for Iteratively SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/plugin-mparticle/README.md
+++ b/packages/plugin-mparticle/README.md
@@ -1,0 +1,3 @@
+# mParticle Browser Plugin
+
+[Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-mparticle/README.md
+++ b/packages/plugin-mparticle/README.md
@@ -1,3 +1,3 @@
-# mParticle Browser Plugin
+# mParticle Browser Plugin for Iteratively SDK
 
 [Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-mparticle/package.json
+++ b/packages/plugin-mparticle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itly/plugin-mparticle",
   "version": "1.4.1",
-  "description": "mParticle Browser Plugin",
+  "description": "mParticle Browser Plugin for Iteratively SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/plugin-schema-validator/README.md
+++ b/packages/plugin-schema-validator/README.md
@@ -1,3 +1,3 @@
-# Schema Validator Plugin
+# Schema Validator Plugin for Iteratively SDK
 
 [Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-schema-validator/README.md
+++ b/packages/plugin-schema-validator/README.md
@@ -1,0 +1,3 @@
+# Schema Validator Plugin
+
+[Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-schema-validator/package.json
+++ b/packages/plugin-schema-validator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itly/plugin-schema-validator",
   "version": "1.4.1",
-  "description": "Iteratively Schema Validator Plugin ",
+  "description": "Iteratively Schema Validator Plugin",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/plugin-schema-validator/package.json
+++ b/packages/plugin-schema-validator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itly/plugin-schema-validator",
   "version": "1.4.1",
-  "description": "Iteratively Schema Validator Plugin",
+  "description": "Schema Validator Plugin for Iteratively SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/plugin-segment-node/README.md
+++ b/packages/plugin-segment-node/README.md
@@ -1,0 +1,3 @@
+# Segment Node Plugin
+
+[Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-segment-node/README.md
+++ b/packages/plugin-segment-node/README.md
@@ -1,3 +1,3 @@
-# Segment Node Plugin
+# Segment Node Plugin for Iteratively SDK
 
 [Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-segment-node/package.json
+++ b/packages/plugin-segment-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itly/plugin-segment-node",
   "version": "1.4.1",
-  "description": "Segment Node Plugin ",
+  "description": "Segment Node Plugin",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/plugin-segment-node/package.json
+++ b/packages/plugin-segment-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itly/plugin-segment-node",
   "version": "1.4.1",
-  "description": "Segment Node Plugin",
+  "description": "Segment Node Plugin for Iteratively SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/plugin-segment/README.md
+++ b/packages/plugin-segment/README.md
@@ -1,0 +1,3 @@
+# Segment Browser Plugin
+
+[Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-segment/README.md
+++ b/packages/plugin-segment/README.md
@@ -1,3 +1,3 @@
-# Segment Browser Plugin
+# Segment Browser Plugin for Iteratively SDK
 
 [Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-segment/package.json
+++ b/packages/plugin-segment/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itly/plugin-segment",
   "version": "1.4.1",
-  "description": "Segment Browser Plugin",
+  "description": "Segment Browser Plugin for Iteratively SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/plugin-snowplow/README.md
+++ b/packages/plugin-snowplow/README.md
@@ -1,3 +1,3 @@
-# Snowplow Browser Plugin
+# Snowplow Browser Plugin for Iteratively SDK
 
 [Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-snowplow/README.md
+++ b/packages/plugin-snowplow/README.md
@@ -1,0 +1,3 @@
+# Snowplow Browser Plugin
+
+[Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-snowplow/package.json
+++ b/packages/plugin-snowplow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itly/plugin-snowplow",
   "version": "1.5.0",
-  "description": "Snowplow Browser Plugin",
+  "description": "Snowplow Browser Plugin for Iteratively SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/plugin-testing/README.md
+++ b/packages/plugin-testing/README.md
@@ -1,3 +1,3 @@
-# Testing Plugin
+# Testing Plugin for Iteratively SDK
 
 [Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-testing/README.md
+++ b/packages/plugin-testing/README.md
@@ -1,0 +1,3 @@
+# Testing Plugin
+
+[Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/plugin-testing/package.json
+++ b/packages/plugin-testing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itly/plugin-testing",
   "version": "1.4.1",
-  "description": "Testing Plugin",
+  "description": "Testing Plugin for Iteratively SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,3 @@
+# Iteratively SDK
+
+[Iteratively SDK](https://github.com/iterativelyhq/itly-sdk/blob/master/README.md)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@itly/sdk",
   "version": "1.4.1",
-  "description": "",
+  "description": "Iteratively SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
Added simple README's. I don't know if it's possible to include relative link to the orimary README or to embed the primary README content to the package README's