### PR TITLE
fix: made Snowplow tracker name, creation, and filtering configurable

### DIFF
--- a/packages/plugin-snowplow/jest.config.js
+++ b/packages/plugin-snowplow/jest.config.js
@@ -1,0 +1,10 @@
+// Jest configuration for api
+const base = require('../../jest.config.base.js');
+const packageJson = require('./package.json');
+
+module.exports = {
+  ...base,
+  testEnvironment: 'jsdom',
+  name: packageJson.name,
+  displayName: packageJson.name,
+};

--- a/packages/plugin-snowplow/lib/__tests__/smoke.test.ts
+++ b/packages/plugin-snowplow/lib/__tests__/smoke.test.ts
@@ -1,0 +1,111 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable import/no-unresolved, import/extensions, import/no-dynamic-require */
+import {
+  ItlyBrowser as Itly, Loggers, Event, PluginLoadOptions,
+} from '@itly/sdk';
+import { SnowplowPlugin, SnowplowOptions } from '../index';
+
+const userId = 'user-id';
+const event: Event = { name: 'My Event' };
+const loadOptions: PluginLoadOptions = { logger: Loggers.None, environment: 'development' };
+
+function mockSnowplowInstance(plugin: SnowplowPlugin) {
+  const snowplowMock = jest.fn();
+  jest.spyOn(plugin, 'snowplow', 'get').mockImplementation(() => snowplowMock);
+  return snowplowMock;
+}
+
+beforeEach(() => {
+  jest.resetModules();
+  // spyConsoleLog = jest.spyOn(console, 'log').mockImplementation();
+
+  // NOTE: Create a script to prevent - 'TypeError: Cannot read property 'parentNode' of undefined'
+  // https://github.com/walmartlabs/little-loader/issues/53
+  const script = document.createElement('script');
+  document.body.appendChild(script);
+});
+
+test('should post to all trackers by default', () => {
+  const plugin = new SnowplowPlugin('vendor', {
+    url: 'snowplow.iterative.ly',
+  });
+
+  const snowplowMock = mockSnowplowInstance(plugin);
+
+  plugin.load(loadOptions);
+  plugin.identify(userId);
+  plugin.page(userId, 'category', 'page-name');
+  plugin.track(userId, event);
+
+  expect(snowplowMock.mock.calls[0][0]).toEqual('setUserId');
+  expect(snowplowMock.mock.calls[1][0]).toEqual('trackPageView');
+  expect(snowplowMock.mock.calls[2][0]).toEqual('trackSelfDescribingEvent');
+});
+
+test('should post to tracker specified in options', () => {
+  const trackerName = 'itly';
+  const plugin = new SnowplowPlugin('vendor', {
+    url: 'snowplow.iterative.ly',
+    trackerNameFilter: trackerName,
+  });
+
+  const snowplowMock = mockSnowplowInstance(plugin);
+
+  plugin.load(loadOptions);
+  plugin.identify(userId);
+  plugin.page(userId, 'category', 'page-name');
+  plugin.track(userId, event);
+
+  expect(snowplowMock.mock.calls[0][0]).toEqual(`setUserId:${trackerName}`);
+  expect(snowplowMock.mock.calls[1][0]).toEqual(`trackPageView:${trackerName}`);
+  expect(snowplowMock.mock.calls[2][0]).toEqual(`trackSelfDescribingEvent:${trackerName}`);
+});
+
+test('should create new tracker if Snowplow is NOT already loaded', () => {
+  const plugin = new SnowplowPlugin('vendor', {
+    url: 'snowplow.iterative.ly',
+  });
+
+  const snowplowMock = jest.fn();
+  jest.spyOn(plugin, 'snowplow', 'get')
+    // First check for 'window.snowplow' returns undefined (aka Snowplow doesn't exist yet)
+    .mockImplementationOnce(() => undefined)
+    .mockImplementation(() => snowplowMock);
+
+  plugin.load(loadOptions);
+
+  expect(snowplowMock.mock.calls[0][0]).toEqual('newTracker');
+});
+
+test('should NOT create new tracker if Snowplow is already loaded', () => {
+  const plugin = new SnowplowPlugin('vendor', {
+    url: 'snowplow.iterative.ly',
+  });
+
+  const snowplowMock = jest.fn();
+  jest.spyOn(plugin, 'snowplow', 'get')
+    // First check for 'window.snowplow' returns a function (aka Snowplow is already loaded)
+    .mockImplementationOnce(() => jest.fn())
+    .mockImplementation(() => snowplowMock);
+
+  plugin.load(loadOptions);
+
+  expect(snowplowMock).not.toHaveBeenCalled();
+});
+
+test('should always create new tracker if forceNewTracker=true ', () => {
+  const plugin = new SnowplowPlugin('vendor', {
+    url: 'snowplow.iterative.ly',
+    forceNewTracker: true,
+  });
+
+  const snowplowMock = jest.fn();
+  jest.spyOn(plugin, 'snowplow', 'get')
+    // First check for 'window.snowplow' returns a function (aka Snowplow is already loaded)
+    .mockImplementationOnce(() => jest.fn())
+    .mockImplementation(() => snowplowMock);
+
+  plugin.load(loadOptions);
+
+  expect(snowplowMock.mock.calls[0][0]).toEqual('newTracker');
+});

--- a/packages/plugin-snowplow/lib/index.ts
+++ b/packages/plugin-snowplow/lib/index.ts
@@ -35,8 +35,6 @@ export interface SnowplowTrackOptions extends SnowplowCallOptions {
   contexts?: SnowplowContext[];
 }
 
-type RequiredExcept<T, K extends keyof T> = Required<Omit<T, K>> & Partial<Pick<T, K>>;
-
 /**
  * Snowplow Browser Plugin for Iteratively SDK
  */

--- a/packages/plugin-snowplow/lib/index.ts
+++ b/packages/plugin-snowplow/lib/index.ts
@@ -6,6 +6,25 @@ import {
 export type SnowplowOptions = {
   url: string;
   config?: {};
+  /**
+   * Will force creation of a new dedicated tracker for Itly events.
+   * If you do not have a pre-existing Snowplow tracker we will create one for you by default.
+   * Set to true if you have an existing tracker you want to keep seperate from Itly events.
+   * @default false
+   */
+  forceNewTracker?: boolean;
+  /**
+   * If a new tracker is created, this will be it's name
+   * @default 'itly'
+   */
+  newTrackerName?: string;
+  /**
+   * The name(s) of the trackers that events should be sent to
+   * e.g. 'itly', 'itly;tracker2'
+   * https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/managing-multiple-trackers/
+   * @default undefined - events are sent to all trackers
+   */
+  trackerNameFilter?: string;
 };
 
 export interface SnowplowContext {
@@ -28,10 +47,21 @@ export interface SnowplowTrackOptions extends SnowplowCallOptions {
   contexts?: SnowplowContext[];
 }
 
+type RequiredExcept<T, K extends keyof T> = Required<Omit<T, K>> & Partial<Pick<T, K>>;
+
 /**
  * Snowplow Browser Plugin for Iteratively SDK
  */
 export class SnowplowPlugin extends RequestLoggerPlugin {
+  private readonly options: RequiredExcept<SnowplowOptions, 'config' | 'trackerNameFilter'> = {
+    url: '',
+    forceNewTracker: false,
+    newTrackerName: 'itly',
+    trackerNameFilter: undefined,
+  };
+
+  private readonly trackerNameFilter: string;
+
   get snowplow(): any {
     // eslint-disable-next-line no-restricted-globals
     const s: any = typeof self === 'object' && self.self === self && self;
@@ -40,24 +70,31 @@ export class SnowplowPlugin extends RequestLoggerPlugin {
 
   constructor(
     readonly vendor: string,
-    private options: SnowplowOptions,
+    snowplowOptions: SnowplowOptions,
   ) {
     super('snowplow');
+    // apply user override options
+    this.options = { ...this.options, ...snowplowOptions };
+    // create tag for trackers to send events to e.g. ':itly', ':itly;tracker2', ''
+    this.trackerNameFilter = this.options.trackerNameFilter ? `:${this.options.trackerNameFilter}` : '';
   }
 
   load(options: PluginLoadOptions) {
     super.load(options);
-    if (!this.snowplow) {
+    const wasSnowplowAlreadyLoaded = !!this.snowplow;
+    if (!wasSnowplowAlreadyLoaded) {
       // Snowplow (https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/javascript-tracker/web-quick-start-guide/)
       // @ts-ignore
       // eslint-disable-next-line
       ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)};p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","//cdn.jsdelivr.net/gh/snowplow/sp-js-assets@2.17.3/sp.js","snowplow"));
-      this.snowplow('newTracker', 'itly', this.options.url, this.options.config);
+    }
+    if (!wasSnowplowAlreadyLoaded || this.options.forceNewTracker) {
+      this.snowplow('newTracker', this.options.newTrackerName, this.options.url, this.options.config);
     }
   }
 
   identify(userId: string | undefined, properties?: Properties) {
-    this.snowplow('setUserId', userId);
+    this.snowplow(`setUserId${this.trackerNameFilter}`, userId);
   }
 
   page(userId?: string, category?: string, name?: string, properties?: Properties, options?: SnowplowPageOptions) {
@@ -66,7 +103,7 @@ export class SnowplowPlugin extends RequestLoggerPlugin {
       'page',
       `${userId}, ${category}, ${name}, ${this.toJsonStr(properties, contexts)}`,
     );
-    this.snowplow('trackPageView', name, undefined, contexts, undefined, this.wrapCallback(responseLogger, callback));
+    this.snowplow(`trackPageView${this.trackerNameFilter}`, name, undefined, contexts, undefined, this.wrapCallback(responseLogger, callback));
   }
 
   track(userId: string | undefined, { name, properties, version }: Event, options?: SnowplowTrackOptions) {
@@ -76,7 +113,7 @@ export class SnowplowPlugin extends RequestLoggerPlugin {
       'track',
       `${userId}, ${name}, ${this.toJsonStr(properties, contexts)}`,
     );
-    this.snowplow('trackSelfDescribingEvent', {
+    this.snowplow(`trackSelfDescribingEvent${this.trackerNameFilter}`, {
       schema: `iglu:${this.vendor}/${name}/jsonschema/${schemaVer}`,
       data: properties,
     }, contexts, undefined, this.wrapCallback(responseLogger, callback));


### PR DESCRIPTION
Hoping this will work for all use cases and preserve the current default.

```
// Default (current)
// * Only create a new tracker if one doesn't already exist
// * Events are sent to all Snowplow trackers
{
  forceNewTracker: false,
  newTrackerName: 'itly',
  trackerNameFilter: undefined,
}

// Dedicated tracker
// * Force creation of a dedicated tracker 'itly'
// * Events are only sent to the 'itly' tracker
{
  forceNewTracker: true,
  newTrackerName: 'itly',
  trackerNameFilter: 'itly',
}

// Track to multiple trackers
// * Force creation of a new tracker 'itly'
// * Events can be sent to multiple trackers if desired
{
  forceNewTracker: true,
  newTrackerName: 'itly',
  trackerNameFilter: 'itly;tracker2;',
}
```